### PR TITLE
chore(nextjs): set `outputFileTracingRoot` to supress warning

### DIFF
--- a/examples/nextjs/next.config.mjs
+++ b/examples/nextjs/next.config.mjs
@@ -1,0 +1,15 @@
+// @ts-check
+import path from "node:path";
+
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  // In our arcjet/examples monorepo Next.js warns about the root
+  // `package-lock.json`. Here we tell Next.js to ignore it and instead use
+  // the adjacent `package-lock.json` file for tracing instead.
+  // See: https://nextjs.org/docs/app/api-reference/config/next-config-js/output#caveats
+  outputFileTracingRoot: path.join(import.meta.dirname, "."),
+};
+
+export default nextConfig;


### PR DESCRIPTION
Configure Next.js `outputFileTracingRoot` to suppress tracing warning. Closes #37.